### PR TITLE
:memo: fixes alignment on options table & escapes pipe character

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ export default {
 
 ## options: plugin instance
 
-Name                |    default     | required | About
-------------------  | -------------  | -------- | ------
-store               |                |  `true`  | instance of store
-delay               |      `500`     |  `false` | delay for labels to load
-separatorText       |       `|`      |  `false` | separator text
-loaderMsg           |  `loading...`  |  `false` | loader message
+Name          | Default      | Required | About
+:-------------|:------------:|:--------:|:-------------------------
+store         |              | `true`   | instance of store
+delay         | `500`        | `false`  | delay for labels to load
+separatorText | `\|`         | `false`  | separator text
+loaderMsg     | `loading...` | `false`  | loader message


### PR DESCRIPTION
I've just fixed options table alignment and escapes it's pipe character.